### PR TITLE
Docker image could be build via maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ service_data
 .project
 .settings
 __pycache__
+main/appstemp

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
 
 			<!-- Docker plugin. -->
 			<!-- http://dmp.fabric8.io/ -->
+			<!-- mvn docker:build -->
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
@@ -148,15 +149,6 @@
 						</image>
 					</images>
 				</configuration>
-				<executions>
-					<execution>
-						<id>build</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>build</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 	<!-- When executing mvn, it cleans the target directory, and then creates 
 		the package and copy the resources. -->
 	<build>
-		<defaultGoal>clean package</defaultGoal>
+		<defaultGoal>clean package install</defaultGoal>
 
 		<!-- Name of the target jar (no version in the name). -->
 		<plugins>
@@ -135,6 +135,29 @@
 				</configuration>
 			</plugin>
 
+			<!-- Docker plugin. -->
+			<!-- http://dmp.fabric8.io/ -->
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.35.0</version>
+				<configuration>
+					<images>
+						<image>
+							<name>benchmarksql-service</name>
+						</image>
+					</images>
+				</configuration>
+				<executions>
+					<execution>
+						<id>build</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>build</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 	<!-- When executing mvn, it cleans the target directory, and then creates 
 		the package and copy the resources. -->
 	<build>
-		<defaultGoal>clean package install</defaultGoal>
+		<defaultGoal>clean package</defaultGoal>
 
 		<!-- Name of the target jar (no version in the name). -->
 		<plugins>

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,0 @@
-appstemp


### PR DESCRIPTION
The maven default goal does not include docker. It can be built with 

    mvn docker:build 