### PR TITLE
Fix drop script of stored function for PostgreSQL

### DIFF
--- a/src/main/resources/sql.postgres/storedProcedureDrops.sql
+++ b/src/main/resources/sql.postgres/storedProcedureDrops.sql
@@ -1,6 +1,6 @@
 drop function if exists bmsql_proc_new_order (integer, integer, integer, integer[], integer[], integer[]);
 drop function if exists bmsql_proc_stock_level(integer, integer, integer);
 drop function if exists bmsql_proc_payment(integer, integer, integer, integer, integer, varchar(16), decimal(6,2));
-drop function if exists bmsql_proc_order_status (integer, integer, integer, var(16));
+drop function if exists bmsql_proc_order_status (integer, integer, integer, varchar(16));
 drop function if exists bmsql_cid_from_clast(integer, integer, varchar(16));
 drop function if exists bmsql_proc_delivery_bg (integer, integer, integer);


### PR DESCRIPTION
This PR fix a problem:

When running the drop script by `./runDatabaseDestroy.sh sample.postgresql.properties`

It will raise `ERROR: type "var" does not exist`.

Here's the log:

```txt
# ------------------------------------------------------------
# Loading SQL file ./sql.postgres/storedProcedureDrops.sql
# ------------------------------------------------------------
drop function if exists bmsql_proc_new_order (integer, integer, integer, integer[], integer[], integer[]);
drop function if exists bmsql_proc_stock_level(integer, integer, integer);
drop function if exists bmsql_proc_payment(integer, integer, integer, integer, integer, varchar(16), decimal(6,2));
drop function if exists bmsql_proc_order_status (integer, integer, integer, var(16));
ERROR: type "var" does not exist
drop function if exists bmsql_cid_from_clast(integer, integer, varchar(16));
drop function if exists bmsql_proc_delivery_bg (integer, integer, integer);
```
